### PR TITLE
Larger initial SimpleVector to reduce realloc calls

### DIFF
--- a/SimpleVector.hpp
+++ b/SimpleVector.hpp
@@ -112,8 +112,8 @@ public:
 		{
 			inc = ( capacity >> 1 ) + 16;
 			if ( maxInc > 0 && inc > maxInc )
-				inc = maxInc;
-			capacity += inc;
+				inc = maxInc ;
+			capacity += inc ;
 			s = (T *)realloc( s, sizeof( T ) * capacity ) ;
 			if ( s == NULL ) 
 			{


### PR DESCRIPTION
SimpleVector was growing from size 1. It needed several realloc calls even for small vectors. Profiler suggested that realloc took significant time.

With this PR, SimpleVector grows from size 16. This reduces the running time of fastq-extractor from 4h12m to 3h on my data. There is probably more room for improvement but that will be more complex.