### PR TITLE
Keep partial alleles if their exons structure is complete

### DIFF
--- a/run-t1k
+++ b/run-t1k
@@ -9,7 +9,7 @@ use File::Basename ;
 
 my $progName = "run-t1k" ;
 
-die "T1K v1.0.3-r191 usage: ./$progName [OPTIONS]:\n".
+die "T1K v1.0.4-r196 usage: ./$progName [OPTIONS]:\n".
     "Required:\n".
     #"\t[Input]:\n".
     "\t-1 STRING -2 STRING: path to paired-end read files\n".

--- a/t1k-build.pl
+++ b/t1k-build.pl
@@ -22,7 +22,8 @@ die "$progName usage: ./$progName [OPTIONS]:\n".
 		"\t-o STRING: output folder (default: ./)\n".
 		"\t-g STRING: genome annotation file (default: not used)\n".
 		"\t--target STRING: gene name keyword (default: no filter)\n".
-		"\t--prefix STRING: file prefix (default: based on --target or -o)\n"
+		"\t--prefix STRING: file prefix (default: based on --target or -o)\n".
+    "\t--ignore-partial: ignore partial allele at all (default: fill in intron if exons are complete)\n"
 		if (@ARGV == 0);
 
 
@@ -45,6 +46,7 @@ my $annotationFile = "" ;
 my $downloadPath = "" ;
 my $targetGene = "" ;
 my $outputPrefix = "" ;
+my $ignorePartial = 0 ;
 
 for ($i = 0 ; $i < @ARGV ; ++$i) 
 {
@@ -83,6 +85,11 @@ for ($i = 0 ; $i < @ARGV ; ++$i)
 		$outputPrefix = $ARGV[$i + 1] ;
 		++$i ;
 	}
+  elsif ( $ARGV[$i] eq "--ignorePartial")
+  {
+    $ignorePartial = 1 ;
+    ++$i ;
+  }
 	else
 	{
 		die "Unknown parameter ".$ARGV[$i]."\n" ;
@@ -141,7 +148,7 @@ if ($ipdDat ne "")
 {
 	my $options = "" ;
 	$options .= " --gene $targetGene" if ($targetGene ne "") ;
-
+  $options .= "--ignorePartial" if ($ignorePartial == 1) ;
 	system_call("perl $WD/ParseDatFile.pl $ipdDat --mode dna $options > $dnaSeqFile") ;
 	system_call("perl $WD/ParseDatFile.pl $ipdDat --mode rna $options > $rnaSeqFile") ;
 }


### PR DESCRIPTION
- For those partial alleles missing an intron, use the most common intron sequence for the corresponding exons to fill in.