### PR TITLE
Update database download procedure

### DIFF
--- a/t1k-build.pl
+++ b/t1k-build.pl
@@ -8,6 +8,7 @@ use Cwd 'cwd' ;
 use Cwd 'abs_path' ;
 use File::Basename ;
 use File::Path 'make_path' ;
+use IO::Uncompress::Unzip qw(unzip $UnzipError) ;
 
 my $progName = "t1k-build.pl" ;
 
@@ -116,18 +117,20 @@ if ($ipdDat eq "" and $downloadPath ne "")
 {
 	if (uc($downloadPath) eq "IPD-IMGT/HLA")	
 	{
-		system_call("curl -o $outputDirectory/hla.dat http://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla.dat") ;
 		$ipdDat = "$outputDirectory/hla.dat" ;
+		system_call("curl -o $ipdDat.zip https://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla.dat.zip") ;
+		unzip "$ipdDat.zip" => $ipdDat
+			or die "unzip failed: $UnzipError\n";
 	}
 	elsif (uc($downloadPath) eq "IPD-KIR")
 	{
-		system_call("curl -o $outputDirectory/kir.dat https://ftp.ebi.ac.uk/pub/databases/ipd/kir/kir.dat") ;
-		$ipdDat = "$outputDirectory/kir.dat"
+		$ipdDat = "$outputDirectory/kir.dat" ;
+		system_call("curl -o $ipdDat https://ftp.ebi.ac.uk/pub/databases/ipd/kir/kir.dat") ;
 	}
 	else
 	{
-		system_call("curl -o $outputDirectory/t1k_ref.dat $downloadPath") ;
 		$ipdDat = "$outputDirectory/t1k_ref.dat" ;
+		system_call("curl -o $ipdDat $downloadPath") ;
 	}
 }
 


### PR DESCRIPTION
Readme (https://github.com/ANHIG/IMGTHLA#up-to-april-2024) stated that

> all hla.dat files are now provided as a zipped file

At the time of writing:

- `hla.dat.zip`: version 3.59.0
- `hla.dat`: version 3.58.0

so let's download `hla.dat.zip` instead of outdated `hla.dat`.

Also use secure connection for the sake of safety.