### PR TITLE
Add -fsigned-char to the Makefile for consistent char behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS= -O3 -g #-pg #-Wall #-O3
+CXXFLAGS= -O3 -g -fsigned-char #-pg #-Wall #-O3
 LINKPATH= -I./samtools-0.1.19 -L./samtools-0.1.19 -I./htslib-1.15.1/ -L./htslib-1.15.1/
 LINKFLAGS = -lpthread -lz 
 DEBUG=


### PR DESCRIPTION
Some compilers default to unsigned char, which leads to inconsistent behavior across architectures. Adding -fsigned-char enforces a predictable signed representation.

This is particularly useful when building on aarch64 platforms, for example Ubuntu 24.04 arm64 or macOS arm64 systems running on Apple Silicon, where default char signedness can differ from x86 based builds.