### PR TITLE
Fixed spurious semicolon that disabled a check

### DIFF
--- a/VariantCaller.hpp
+++ b/VariantCaller.hpp
@@ -372,7 +372,7 @@ public:
 			{
 				int seqIdx = fragmentAssignment[i].seqIdx ;
 				struct _overlap o = SelectOverlapFromFragmentOverlap(k, fragmentAssignment[i]) ;
-				if (containCandidateVar(o.seqStart, o.seqEnd, seqCandidateAccuCount[seqIdx])) ;
+				if (containCandidateVar(o.seqStart, o.seqEnd, seqCandidateAccuCount[seqIdx]))
 					break ;
 			}
 
@@ -608,7 +608,7 @@ public:
 			{
 				int seqIdx = fragmentAssignment[i].seqIdx ;
 				struct _overlap o = SelectOverlapFromFragmentOverlap(k, fragmentAssignment[i]) ;
-				if (containCandidateVar(o.seqStart, o.seqEnd, seqCandidateAccuCount[seqIdx])) ;
+				if (containCandidateVar(o.seqStart, o.seqEnd, seqCandidateAccuCount[seqIdx])) 
 					break ;
 			}
 


### PR DESCRIPTION
We observed spurious segfault in the post-analysis step of T1K that seemed to be coming from this check that seemed to be disabled 
@mourisl - would you be interested in taking this fix in? 
Happy to provide data to replicate