### PR TITLE
Update genotyper.hpp to fix secondary allele overwriting bug

### DIFF
--- a/Genotyper.hpp
+++ b/Genotyper.hpp
@@ -2134,7 +2134,8 @@ public:
 				buffer = secondaryAlleles ;
 				sep = ';' ;
 			}
-			buffer[0] = '\0' ;
+			if (type <= 1)
+				buffer[0] = '\0' ;
 
 			int size = selectedAlleles[geneIdx].size() ;
 			selectedMajorAlleles.Clear() ;

--- a/Genotyper.hpp
+++ b/Genotyper.hpp
@@ -2134,7 +2134,7 @@ public:
 				buffer = secondaryAlleles ;
 				sep = ';' ;
 			}
-			if (type <= 1)
+			if (type <= 2)
 				buffer[0] = '\0' ;
 
 			int size = selectedAlleles[geneIdx].size() ;


### PR DESCRIPTION
See issue #58 for full description. I tested this fix in my genotyping pipeline for non-human MHC typing using a custom allele database. 